### PR TITLE
docs: Add status badges and confirmed working status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Task Blaster - Kanban Orchestration App
 
+[![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
+[![Node.js](https://img.shields.io/badge/Node.js-22%2B-green.svg)](https://nodejs.org/)
+[![Docker](https://img.shields.io/badge/Docker-Ready-blue.svg)](https://www.docker.com/)
+
 A modern Kanban-style task management application built as a monorepo with a Fastify API backend and React TypeScript frontend.
+
+> ✅ **Status**: Fully tested and working - API, database, and Docker setup confirmed operational.
 
 ## 🏗️ Architecture
 


### PR DESCRIPTION
This is a small PR to test the GitHub UI and add some polish to the README:

- Add ISC license, Node.js 22+, and Docker Ready badges
- Add status confirmation that setup is fully tested and operational  
- Improve visual appeal and provide quick status overview for users

This should be a simple merge to test if the GitHub PR interface is working properly now with smaller changes.